### PR TITLE
Replace Neocom with Neocom II

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ While these fitting tools haven't been updated in some time they can still be us
 * (XML) [Eve Droid](https://play.google.com/store/apps/details?id=dk.alxb.evedroid) - EVE Droid is a character monitoring and ship fitting tool for EVE Online.
 * (N/A) [Mining Helper](https://play.google.com/store/apps/details?id=com.randomlettersandnumbers15645151gd65fg16d5fgs46r84tserg51f3d21ger6.eveminer) - This simple app let's you select some ores and will fetch their prices in Tradehubs.
 
-##### IOS
-* (ESI) [NeoCom](https://itunes.apple.com/ca/app/neocom-for-eve-online/id418895101?mt=8) - View your EVE Online characters and skills, browse EVE Online items database, analyze market information, test ship fits on your iPhone/iPad or iPod Touch.
+##### iOS
+* [Neocom II for EVE Online](https://itunes.apple.com/ca/app/neocom-ii-for-eve-online/id1257353838?mt=8) - View your EVE Online characters and skills, browse EVE Online items database, analyze market information, test ship fits on your iPhone/iPad or iPod Touch.
 
 ---------
 


### PR DESCRIPTION
Neocom (first) using XML API. Neocom II ported to ESI API. Update app name and app link.