### PR TITLE
Remove link that leads to malware (possibly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ While these fitting tools haven't been updated in some time they can still be us
 * [Pathfinder](https://www.pathfinder-w.space/) - wormhole mapping tool
 * [anoik.is](http://anoik.is/) - Wormhole info tool.  Tells you about the WH and who is probably in it.  Battles and links to zkillboard for kills.
 * [eve-wh.space](https://eve-wh.space/) - Information about wormhole systems, WH sites; WH database. Integration with ESI, zKillboard. Focused on minimalistic UI and usability.
-* [WormBoard](http://fetox-developments.com/wormboard/) - Wormhole corporation ranking site and statistics including killtime distribution and expected fleetsizes.
 
 #### Killboards
 


### PR DESCRIPTION
Wormboard leads to a site that tries to fool you to install malware of some kind. Can anyone else confirm?