### PR TITLE
Add Short Circuit

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Outdated fitting tools used to be listed, but they are so far out of date they r
 * [Pathfinder](https://www.pathfinder-w.space/) - wormhole mapping tool
 * [anoik.is](http://anoik.is/) - Wormhole info tool.  Tells you about the WH and who is probably in it.  Battles and links to zkillboard for kills.
 * [eve-wh.space](https://eve-wh.space/) - Information about wormhole systems, WH sites; WH database. Integration with ESI, zKillboard. Focused on minimalistic UI and usability.
+* [Short Circuit](https://github.com/secondfry/shortcircuit) - tool for finding shortest path between systems using Tripwire wormhole connections. 
 
 #### Killboards
 


### PR DESCRIPTION
Short Circuit (previously known as Pathfinder) is a desktop application which is able to find the shortest path between solar systems (including wormholes) using data retrieved from Eve SDE and 3rd party wormhole mapping tools (only Tripwire at the moment).