### PR TITLE
Add eve-calendars.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You can participate with CCP devs and third party devs by [joining Tweetfleet on
 * [Clone Guard](https://clone-guard.firebaseapp.com/) - Never lose another training clone: Notifies you if you forgot to switch to the right clone
 * [Eve Fleet Simulator](https://evefleetsimulator.com/) - Simulate fleet PvP and compare/analyse fits and hulls.
 * [EVE Workbench](https://www.eveworkbench.com/) - EVE Workbench is a web based tool for the EVE community, allowing players to browse the market, create haul routes and browse & share fittings.
+* [eve-calendars.com](https://www.eve-calendars.com) - Convenient out-of-game access to character's calendar. Allows players to use their favourite calendar app on the desktop or mobile as also see events in their preferred time zone.
+
 
 #### EveMail
 * [eve-mails.com](https://www.eve-mails.com) - eve-mails.com: Read, delete and write eve-mails from your browser. Allows for tracking mails of multiple accounts at the same time.


### PR DESCRIPTION
A service that provides convenient and private out-of-game access to character's calendar. It allows players to use their favourite calendar app on the desktop or mobile as also see events in their preferred time zone.


<img width="935" alt="eve-calendars-screenshot" src="https://user-images.githubusercontent.com/37100/61180640-d6d22400-a619-11e9-8820-1c7ec3cd66ae.png">


- **Website**: https://www.eve-calendars.com
- **Source code**: https://github.com/lunohodov/eventical