### PR TITLE
Remove EveMails

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ You can participate with CCP devs and third party devs by [joining Tweetfleet on
 
 
 #### EveMail
-* [eve-mails.com](https://www.eve-mails.com) - eve-mails.com: Read, delete and write eve-mails from your browser. Allows for tracking mails of multiple accounts at the same time.
 * [Fuzzwork Mail](https://evemail.fuzzwork.co.uk) - Fuzzwork Evemail, an ESI Evemail client. Clientside based, no storage.
 * [PodMail](https://podmail.zzeve.com) - PodMail, an ESI EveMail client. Mobile friendly web platform for accessing your evemails.
 * [Spacemail](https://spacemail.xyz) - Spacemail, ESI Mail and Calendar client. Responsive open-source web-app.


### PR DESCRIPTION
EveMails seems to be gone, Safari says it cant find it?