### PR TITLE
Remove EVE Traders Handbook listing (abandonware)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ Outdated fitting tools used to be listed, but they are so far out of date they r
 #### Market
 
 * [EVE Trade](https://evetrade.space) - a tool to fill the gaps that EVE Central left behind. It allows users to find great deals when it comes to station trading or hauling. The tool will run market analysis on station to station trades as well as region to region trades (public citadels included).
-* [Eve Traders Handbook](http://matthewpennell.github.io/eve-traders-handbook/) - a multi-purpose web application for traders, importers, and manufacturers.
 * [REvernus](https://github.com/Meigs2/REvernus) - Inventory and market data (Windows/MacOSX application).
 * [ISK Per Hour](https://eveiph.github.io/) EVE - Isk per Hour is a Windows program that allows players of EVE Online to determine ways to maximize their Isk per Hour through manufacturing, mining, invention, and reverse engineering.
 * [EveKit - Market](https://evekit.orbital.enterprises/#/md/main) - Market price history and book data (including complete history).  Use JSON/REST or [Swagger](http://swagger.io/) generated clients.


### PR DESCRIPTION
The listed app is no longer maintained and won't even compile on modern development stack. I am the author.