### PR TITLE
Service Support and Community Apps for Alliance Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ While these fitting tools haven't been updated in some time they can still be us
 
 #### Auth Systems
 * [Alliance Auth](https://gitlab.com/allianceauth/allianceauth) - An auth system for EVE Online to help in-game organizations manage online service access.
+    * [Services](https://allianceauth.readthedocs.io/en/latest/features/services/index.html#supported-services) Discord, Mumble, Openfire/Jabber, phpBB3, SMF, Teamspeak3, XenForo, Discourse and WikiJS (AA Community App)
+    * [Community Apps](https://gitlab.com/allianceauth/community-creations) Fully featured Community built apps to extend Alliance Auth
 * [AVRSE Auth](https://github.com/skyride/avrse-auth) - An FC focussed auth system with support for discord, mumble and IPB. Handles characters/assets/skills/structure management.
 
 #### Discord Tools


### PR DESCRIPTION
Alliance Auth has accrued a wide variety of fully featured community apps that i'd like to highlight.

But I cant really think of a nice way to do this rather than a giant list. Settling for a link to the Alliance Auth Community Creations repo instead. 

Open to feedback to best highlight these applications to the community https://gitlab.com/allianceauth/community-creations