### PR TITLE
Add new rfc7234 caching capable esi client

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ You can participate with CCP devs and third party devs by [joining Tweetfleet on
 * [iveeCore](https://github.com/aineko-m/iveeCore) - PHP Library for calculations of industrial activities
 * [Eseye](https://github.com/eveseat/eseye) - Standalone, Dynamic PHP Client Library for the ESI API
 * [swagger-eve-php](https://github.com/tkhamez/swagger-eve-php) - Auto-generated OpenAPI client for ESI
-* [Esi-Client](https://github.com/seatplus/esi-client) - A rfc7234 (cachinng) capable ESI (Eve Swagger Interface) Client Library using guzzle7/PSR Client  
+* [Esi-Client](https://github.com/seatplus/esi-client) - A rfc7234 (caching) capable ESI (Eve Swagger Interface) Client Library using guzzle7/PSR Client  
 
 #### Python
 * [EsiPy](https://github.com/Kyria/EsiPy) - Python library (on top of pyswagger) to interact with the ESI API

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ You can participate with CCP devs and third party devs by [joining Tweetfleet on
 * [iveeCore](https://github.com/aineko-m/iveeCore) - PHP Library for calculations of industrial activities
 * [Eseye](https://github.com/eveseat/eseye) - Standalone, Dynamic PHP Client Library for the ESI API
 * [swagger-eve-php](https://github.com/tkhamez/swagger-eve-php) - Auto-generated OpenAPI client for ESI
+* [Esi-Client](https://github.com/seatplus/esi-client) - A rfc7234 (cachinng) capable ESI (Eve Swagger Interface) Client Library using guzzle7/PSR Client  
 
 #### Python
 * [EsiPy](https://github.com/Kyria/EsiPy) - Python library (on top of pyswagger) to interact with the ESI API


### PR DESCRIPTION
As of today this esi client only supports Laravel Cache Middleware. However Kevinrob/guzzle-cache-middleware supports various others such as:

Doctrine cache, Laravel cache, Flysystem, PSR6, WordPress Object Cache

if you plan to use this client with any of these a proper CacheMiddleware would be needed. Same goes to the HTTP client. This client and its cache middleware had been designed to use with Guzzle7 (but you can use it with any PSR-7 HTTP client). Please submit your PR accordingly implementing other HTTP clients.